### PR TITLE
Tidy with ESLint:Recommended

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,10 +28,6 @@ function isObject (o) {
   return 'object' === typeof o
 }
 
-function isFunction (f) {
-  return 'function' === typeof f
-}
-
 function isString(s) {
   return 'string' === typeof s
 }
@@ -169,7 +165,9 @@ exports.unboxBody = function (boxed, key) {
   var msg = pb.multibox_open_body(boxed, key)
   try {
     return JSON.parse(''+msg)
-  } catch (_) { }
+  } catch (_) {
+    return
+  }
 }
 
 exports.unbox = function (boxed, keys) {
@@ -180,8 +178,9 @@ exports.unbox = function (boxed, keys) {
   try {
     var msg = pb.multibox_open(boxed, sk)
     return JSON.parse(''+msg)
-  } catch (_) { }
-  return
+  } catch (_) {
+    return
+  }
 }
 
 exports.secretBox = function secretBox (data, key) {

--- a/local-storage.js
+++ b/local-storage.js
@@ -1,5 +1,4 @@
 'use strict'
-var u = require('./util')
 
 function isFunction (f) {
   return 'function' == typeof f

--- a/storage.js
+++ b/storage.js
@@ -51,7 +51,7 @@ ${legacy ? keys.private : JSON.stringify(keys, null, 2)}
 
   function reconstructKeys(keyfile) {
     var privateKey = keyfile
-      .replace(/\s*\#[^\n]*/g, '')
+      .replace(/\s*#[^\n]*/g, '')
       .split('\n').filter(empty).join('')
 
     //if the key is in JSON format, we are good.

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -16,7 +16,6 @@ tape('box, unbox', function (t) {
 tape('return undefined for invalid content', function (t) {
 
   var alice = ssbkeys.generate()
-  var bob = ssbkeys.generate()
 
   var msg = ssbkeys.unbox('this is invalid content', alice.private)
   t.equal(msg, undefined)

--- a/test/fs.js
+++ b/test/fs.js
@@ -1,6 +1,5 @@
 var tape = require('tape')
 var ssbkeys = require('../')
-var crypto = require('crypto')
 var path = require('path')
 var os = require('os')
 var fs = require('fs')

--- a/test/index.js
+++ b/test/index.js
@@ -70,8 +70,8 @@ tape('sign and verify a hmaced object javascript object', function (t) {
   hmac_key = hmac_key.toString('base64')
   hmac_key2 = hmac_key2.toString('base64')
 
-  var keys = ssbkeys.generate()
-  var sig = ssbkeys.signObj(keys.private, hmac_key, obj)
+  keys = ssbkeys.generate()
+  sig = ssbkeys.signObj(keys.private, hmac_key, obj)
   console.log(sig)
   t.ok(sig)
   //verify must be passed the key to correctly verify


### PR DESCRIPTION
There are some unused variables, unused escape characters, and invalid
JS (e.g. reassignment with `var` prefix) that makes this module harder
to grok.

This commit applies the recommended ESLint ruleset to resolve these
problems.