### PR TITLE
Point Travis CI to main, not master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ os:
   - osx
   - windows
 
-# Don't build arbitrary branches, just pull requests + master + semver tags.
+# Don't build arbitrary branches, just pull requests + main + semver tags.
 branches:
   only:
-  - master
+  - main
   - "/^v\\d+\\.\\d+\\.\\d+$/"


### PR DESCRIPTION
Travis CI wasn't running for this repo, because there was an automatic migration from `master` to `main` as the default branch, but we didn't (manually) update the Travis config.
