### PR TITLE
use tilde version range in package.json dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "url": "git://github.com/ssbc/ssb-keys.git"
   },
   "dependencies": {
-    "chloride": "^2.2.8",
+    "chloride": "~2.2.8",
     "mkdirp": "~0.5.0",
-    "private-box": "^0.3.0"
+    "private-box": "~0.3.0"
   },
   "devDependencies": {
     "tape": "^3.0.3"


### PR DESCRIPTION
We don't have package-lock.json and the `dependencies` are specified with a hat `^`, so this means the ranges are pretty loose.

[Tests are failing in `main`](https://github.com/ssb-js/ssb-keys/pull/70), and I realized that's because they are installing `chloride@2.3.0`, because we specified the range `"chloride": "^2.2.8"`.

This PR uses tilde instead of hat, to make the version range more narrow, and thus rejecting `chloride@2.3.0`, but sticking with `chloride@2.2.x`. The tests now pass. We should try to support `chloride@2.3.0` too, but that's another issue.
