### PR TITLE
Add code coverage tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   },
   "devDependencies": {
     "husky": "^4.3.0",
+    "nyc": "^15.1.0",
     "pretty-quick": "^3.0.2",
     "prettier": "^2.1.2",
     "tape": "^3.0.3"
   },
   "scripts": {
-    "test": "tape test/*"
+    "test": "nyc tape test/*"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This is a simple first-step code coverage addition to this repo. `nyc` is run prefixed to `tape test/*` and will simply run `tape` but at the end will report a summary of test coverage on the codebase.

It's clear that we have a lot of code not covered by tests. We should make more PRs to add tests and seek for 100% coverage, especially for ssb-keys which is a highly-depended-on module.

