### PR TITLE
test loadOrCreate, getTag, unboxKey, unboxBody

### DIFF
--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -19,3 +19,16 @@ tape("return undefined for invalid content", function (t) {
   t.equal(msg, undefined);
   t.end();
 });
+
+tape("unboxKey & unboxBody", function (t) {
+  var alice = ssbkeys.generate();
+  var bob = ssbkeys.generate();
+
+  var boxed = ssbkeys.box({ okay: true }, [bob.public, alice.public]);
+  var k = ssbkeys.unboxKey(boxed, alice.private);
+  var msg = ssbkeys.unboxBody(boxed, k);
+  var msg2 = ssbkeys.unbox(boxed, alice.private);
+  t.deepEqual(msg, { okay: true });
+  t.deepEqual(msg, msg2);
+  t.end();
+});

--- a/test/fs.js
+++ b/test/fs.js
@@ -40,3 +40,51 @@ tape("prevent clobbering existing keys", function (t) {
     t.end();
   });
 });
+
+tape("loadOrCreate can load", function (t) {
+  var keyPath = path.join(os.tmpdir(), `ssb-keys-1-${Date.now()}`);
+  var keys = ssbkeys.generate("ed25519");
+  keys.id = keys.id.substring(1);
+  fs.writeFileSync(keyPath, JSON.stringify(keys));
+
+  ssbkeys.loadOrCreate(keyPath, (err, k2) => {
+    t.error(err);
+    t.equal(k2.id, "@" + keys.id);
+    t.end();
+  });
+});
+
+tape("loadOrCreate can create", function (t) {
+  var keyPath = path.join(os.tmpdir(), `ssb-keys-2-${Date.now()}`);
+  t.equal(fs.existsSync(keyPath), false);
+
+  ssbkeys.loadOrCreate(keyPath, (err, keys) => {
+    t.error(err);
+    t.true(keys.public.length > 20, "keys.public is a long string");
+    t.true(keys.private.length > 20, "keys.private is a long string");
+    t.true(keys.id.length > 20, "keys.id is a long string");
+    t.end();
+  });
+});
+
+tape("loadOrCreateSync can load", function (t) {
+  var keyPath = path.join(os.tmpdir(), `ssb-keys-3-${Date.now()}`);
+  var keys = ssbkeys.generate("ed25519");
+  keys.id = keys.id.substring(1);
+  fs.writeFileSync(keyPath, JSON.stringify(keys));
+
+  var k2 = ssbkeys.loadOrCreateSync(keyPath);
+  t.equal(k2.id, "@" + keys.id);
+  t.end();
+});
+
+tape("loadOrCreateSync can create", function (t) {
+  var keyPath = path.join(os.tmpdir(), `ssb-keys-4-${Date.now()}`);
+  t.equal(fs.existsSync(keyPath), false);
+
+  var keys = ssbkeys.loadOrCreateSync(keyPath);
+  t.true(keys.public.length > 20, "keys.public is a long string");
+  t.true(keys.private.length > 20, "keys.private is a long string");
+  t.true(keys.id.length > 20, "keys.id is a long string");
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -99,3 +99,11 @@ tape('ed25519 id === "@" ++ pubkey', function (t) {
 
   t.end();
 });
+
+tape("getTag", function (t) {
+  var hash = "lFluepOmDxEUcZWlLfz0rHU61xLQYxknAEd6z4un8P8=.sha256";
+  var author = "@/02iw6SFEPIHl8nMkYSwcCgRWxiG6VP547Wcp1NW8Bo=.ed25519";
+  t.equal(ssbkeys.getTag(hash), "sha256");
+  t.equal(ssbkeys.getTag(author), "ed25519");
+  t.end();
+});


### PR DESCRIPTION
Previously, public APIs `unboxKey`, `unboxBody`, `getTag` were untested, this PR adds some basic tests for those. Also, `loadOrCreate` got more tests for various cases when it loads or when it creates.

### Code coverage before

```
------------|---------|----------|---------|---------|----------------------------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                      
------------|---------|----------|---------|---------|----------------------------------------
All files   |   81.41 |       68 |   86.05 |   87.65 |                                        
 index.js   |      75 |    68.52 |      70 |   79.35 | 42,66-68,73-76,101,145,153-155,159-166 
 sodium.js  |     100 |    83.33 |     100 |     100 | 10                                     
 storage.js |   86.44 |    63.64 |     100 |      96 | 64,76                                  
 util.js    |   91.67 |    66.67 |     100 |     100 | 6-39,42                                
------------|---------|----------|---------|---------|----------------------------------------
```

### Code coverage after

(Hint, only `index.js` coverage changed)

```
------------|---------|----------|---------|---------|-------------------
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------|---------|----------|---------|---------|-------------------
All files   |   90.45 |       74 |     100 |   97.06 |                   
 index.js   |   90.74 |    77.78 |     100 |   96.74 | 42,101,166        
 sodium.js  |     100 |    83.33 |     100 |     100 | 10                
 storage.js |   88.14 |    68.18 |     100 |      96 | 64,76             
 util.js    |   91.67 |    66.67 |     100 |     100 | 6-39,42           
------------|---------|----------|---------|---------|-------------------
```