### PR TITLE
replace Buffer constructor with modern Buffer factories

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ exports.loadOrCreateSync = function (filename) {
 //(a signature must be a node buffer)
 
 function sign(keys, msg) {
-  if (isString(msg)) msg = new Buffer(msg);
+  if (isString(msg)) msg = Buffer.from(msg);
   if (!isBuffer(msg)) throw new Error("msg should be buffer");
   var curve = getCurve(keys);
 
@@ -104,7 +104,7 @@ function verify(keys, sig, msg) {
   return curves[getCurve(keys)].verify(
     u.toBuffer(keys.public || keys),
     u.toBuffer(sig),
-    isBuffer(msg) ? msg : new Buffer(msg)
+    isBuffer(msg) ? msg : Buffer.from(msg)
   );
 }
 
@@ -113,7 +113,7 @@ function verify(keys, sig, msg) {
 exports.signObj = function (keys, hmac_key, obj) {
   if (!obj) (obj = hmac_key), (hmac_key = null);
   var _obj = clone(obj);
-  var b = new Buffer(JSON.stringify(_obj, null, 2));
+  var b = Buffer.from(JSON.stringify(_obj, null, 2));
   if (hmac_key) b = hmac(b, u.toBuffer(hmac_key));
   _obj.signature = sign(keys, b);
   return _obj;
@@ -124,13 +124,13 @@ exports.verifyObj = function (keys, hmac_key, obj) {
   obj = clone(obj);
   var sig = obj.signature;
   delete obj.signature;
-  var b = new Buffer(JSON.stringify(obj, null, 2));
+  var b = Buffer.from(JSON.stringify(obj, null, 2));
   if (hmac_key) b = hmac(b, u.toBuffer(hmac_key));
   return verify(keys, sig, b);
 };
 
 exports.box = function (msg, recipients) {
-  msg = new Buffer(JSON.stringify(msg));
+  msg = Buffer.from(JSON.stringify(msg));
 
   recipients = recipients.map(function (keys) {
     return sodium.crypto_sign_ed25519_pk_to_curve25519(

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "prettier": "^2.1.2",
     "tape": "^3.0.3"
   },
+  "engines": {
+    "node": ">=5.10.0"
+  },
   "scripts": {
     "test": "nyc tape test/*"
   },

--- a/sodium.js
+++ b/sodium.js
@@ -5,7 +5,7 @@ module.exports = {
   curves: ["ed25519"],
 
   generate: function (seed) {
-    if (!seed) sodium.randombytes((seed = new Buffer(32)));
+    if (!seed) sodium.randombytes((seed = Buffer.alloc(32)));
 
     var keys = seed
       ? sodium.crypto_sign_seed_keypair(seed)

--- a/util.js
+++ b/util.js
@@ -4,8 +4,8 @@ var cl = require("chloride");
 exports.hash = function (data, enc) {
   data =
     "string" === typeof data && enc == null
-      ? new Buffer(data, "binary")
-      : new Buffer(data, enc);
+      ? Buffer.from(data, "binary")
+      : Buffer.from(data, enc);
   return cl.crypto_hash_sha256(data).toString("base64") + ".sha256";
 };
 
@@ -40,5 +40,5 @@ exports.toBuffer = function (buf) {
   if (Buffer.isBuffer(buf)) return buf;
   var i = buf.indexOf(".");
   var start = exports.hasSigil(buf) ? 1 : 0;
-  return new Buffer(buf.substring(start, ~i ? i : buf.length), "base64");
+  return Buffer.from(buf.substring(start, ~i ? i : buf.length), "base64");
 };


### PR DESCRIPTION
The constructor `new Buffer` is deprecated in modern versions of Node.js. We replaced these by `Buffer.from` and `Buffer.alloc` in secret-stack, but now we should do it here too. This PR also requires Node.js to be at least `5.10.0` (so does secret-stack already do that) in order to guarantee that we can use these Buffer factory functions.
