### PR TITLE
create test-verbose script, make test script unverbose

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node": ">=5.10.0"
   },
   "scripts": {
-    "test": "eslint *.js && nyc tape test/*"
+    "test": "eslint *.js && nyc tape test/*",
+    "test-verbose": "VERBOSE_TESTS=1 npm run test"
   },
   "author": "Paul Frazee <pfrazee@gmail.com>",
   "license": "MIT",

--- a/test/box-unbox.js
+++ b/test/box-unbox.js
@@ -6,7 +6,7 @@ tape("box, unbox", function (t) {
   var bob = ssbkeys.generate();
 
   var boxed = ssbkeys.box({ okay: true }, [bob.public, alice.public]);
-  console.log("boxed");
+  if (process.env.VERBOSE_TESTS) console.log("boxed", boxed);
   var msg = ssbkeys.unbox(boxed, alice.private);
   t.deepEqual(msg, { okay: true });
   t.end();

--- a/test/fs.js
+++ b/test/fs.js
@@ -5,7 +5,7 @@ var os = require("os");
 var fs = require("fs");
 
 const keyPath = path.join(os.tmpdir(), `ssb-keys-${Date.now()}`);
-console.log(keyPath);
+if (process.env.VERBOSE_TESTS) console.log(keyPath);
 
 tape("create and load presigil-legacy async", function (t) {
   var keys = ssbkeys.generate("ed25519");

--- a/test/index.js
+++ b/test/index.js
@@ -4,12 +4,12 @@ var crypto = require("crypto");
 var path = "/tmp/ssb-keys_" + Date.now();
 
 tape("create and load async", function (t) {
-  console.log(ssbkeys);
+  if (process.env.VERBOSE_TESTS) console.log(ssbkeys);
   ssbkeys.create(path, function (err, k1) {
     if (err) throw err;
     ssbkeys.load(path, function (err, k2) {
       if (err) throw err;
-      console.log(k1, k2);
+      if (process.env.VERBOSE_TESTS) console.log(k1, k2);
       t.equal(k1.id.toString("hex"), k2.id.toString("hex"));
       t.equal(k1.private.toString("hex"), k2.private.toString("hex"));
       t.equal(k1.public.toString("hex"), k2.public.toString("hex"));
@@ -30,11 +30,11 @@ tape("create and load sync", function (t) {
 tape("sign and verify a javascript object", function (t) {
   var obj = require("../package.json");
 
-  console.log(obj);
+  if (process.env.VERBOSE_TESTS) console.log(obj);
 
   var keys = ssbkeys.generate();
   var sig = ssbkeys.signObj(keys.private, obj);
-  console.log(sig);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
   t.ok(sig);
   t.ok(ssbkeys.verifyObj(keys, sig));
   t.ok(ssbkeys.verifyObj({ public: keys.public }, sig));
@@ -51,7 +51,7 @@ tape("sign and verify a hmaced object javascript object", function (t) {
 
   var keys = ssbkeys.generate();
   var sig = ssbkeys.signObj(keys.private, hmac_key, obj);
-  console.log(sig);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
   t.ok(sig);
   //verify must be passed the key to correctly verify
   t.notOk(ssbkeys.verifyObj(keys, sig));
@@ -69,7 +69,7 @@ tape("sign and verify a hmaced object javascript object", function (t) {
 
   keys = ssbkeys.generate();
   sig = ssbkeys.signObj(keys.private, hmac_key, obj);
-  console.log(sig);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
   t.ok(sig);
   //verify must be passed the key to correctly verify
   t.notOk(ssbkeys.verifyObj(keys, sig));

--- a/test/secretbox.js
+++ b/test/secretbox.js
@@ -5,7 +5,7 @@ tape("secretBox, secretUnbox", function (t) {
   var key = Buffer.from("somewhere-over-the-rainbow-way-up-high");
 
   var boxed = ssbkeys.secretBox({ okay: true }, key);
-  console.log("boxed");
+  if (process.env.VERBOSE_TESTS) console.log("boxed", boxed);
   var msg = ssbkeys.secretUnbox(boxed, key);
   t.deepEqual(msg, { okay: true });
   t.end();


### PR DESCRIPTION
I think Dominic's style of writing tests usually involves `console.log`s sprinkled here and there while we debugged their outputs. That's okay for debugging tests when you're writing tests, but when you're just running the tests (that you already trust to be written correctly), you don't want to see all that input.

This PR puts a `if (process.env.VERBOSE_TESTS)` check before every `console.log` and then adds a new script `test-verbose` which has that env var enabled. Thus, when you run `npm test`, it will be "silent", but if you run `npm run test-verbose` it will give you all those console.log outputs. CI should use `npm test`.
