### PR TITLE
add tests for sign and verify with a weird obj

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,17 @@ tape("sign and verify a hmaced object javascript object", function (t) {
   t.end();
 });
 
+tape("sign and verify with a buffer obj and buffer hmac_key", function (t) {
+  var obj = crypto.randomBytes(40);
+  var hmac_key = crypto.randomBytes(32);
+  var keys = ssbkeys.generate();
+  var sig = ssbkeys.signObj(keys.private, hmac_key, obj);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
+  t.ok(sig);
+  t.ok(ssbkeys.verifyObj(keys, hmac_key, sig));
+  t.end();
+});
+
 tape("seeded keys, ed25519", function (t) {
   var seed = crypto.randomBytes(32);
   var k1 = ssbkeys.generate("ed25519", seed);


### PR DESCRIPTION
I don't know if anyone out there uses ssb-keys this way, but this is currently supported:

`ssbKeys.signObj(keys, someBuffer, anotherBuffer)`

That is, the object being signed is a Buffer. Now, this currently executes without errors because every Buffer is an object. But should we forbid this usage?

Created as a draft to indicate I don't want to merge *yet* before we discuss about it.