### PR TITLE
Bump version of chloride to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/ssbc/ssb-keys.git"
   },
   "dependencies": {
-    "chloride": "~2.2.8",
+    "chloride": "~2.4.0",
     "mkdirp": "~0.5.0",
     "private-box": "~0.3.0"
   },
@@ -18,7 +18,7 @@
     "nyc": "^15.1.0",
     "prettier": "^2.1.2",
     "pretty-quick": "^3.0.2",
-    "tape": "^3.0.3"
+    "tape": "^5.1.1"
   },
   "engines": {
     "node": ">=5.10.0"

--- a/test/secretbox.js
+++ b/test/secretbox.js
@@ -2,7 +2,9 @@ var tape = require("tape");
 var ssbkeys = require("..");
 
 tape("secretBox, secretUnbox", function (t) {
-  var key = Buffer.from("somewhere-over-the-rainbow-way-up-high");
+  var key = Buffer.from(
+    "somewhere-over-the-rainbow-way-up-high".substring(0, 32)
+  );
 
   var boxed = ssbkeys.secretBox({ okay: true }, key);
   if (process.env.VERBOSE_TESTS) console.log("boxed", boxed);


### PR DESCRIPTION
Hunting down some build errors, I noticed that the chloride dependency was out of date.  This brings it up to current and fixes a problem in the tests (where it was incorrectly passing a key of the wrong length) so that all tests pass.