### PR TITLE
Bump version of chloride to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git://github.com/ssbc/ssb-keys.git"
   },
   "dependencies": {
-    "chloride": "~2.4.0",
+    "chloride": "~2.4.1",
     "mkdirp": "~0.5.0",
     "private-box": "~0.3.0"
   },


### PR DESCRIPTION
Chloride 2.4.1 was just released which fixes an issue where errors were emitted which shouldn't have been:

https://github.com/ssb-js/chloride/commit/287922f20a94f02e0c3d6ce6cb8d6fb79d9e30a6

This bumps that dependency.