### PR TITLE
tests for sign/verify functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ var hmac_key = Buffer.from("7b6m0wZtYR0TevSgeNstWZUZam3IIG2B").toString(
 // The `hmac_key` is a fixed value that applies to _THIS_ signature and is used
 // to authenticate the data, `k` is the sender keys
 var obj = ssbKeys.signObj(k, hmac_key, { foo: "bar" });
-/* obj => 
+/* obj =>
   {
     "foo": "bar",
     "signature": "H39taOYa2emULWa1YDEaoLJBrbZ2GHsuVA6VsE9A1hbtpMcWpqXmZisH+nItx8BQR6JOO58K/uohMJkCrUKABQ==.sig.ed25519"
@@ -113,6 +113,14 @@ curve defaults to `ed25519` (and no other type is currently supported)
 seed should be a 32 byte buffer.
 
 `keys` is an object as described in [`keys`](#keys) section.
+
+### sign(keys, str)
+
+signs a string `str`, and returns the signature string.
+
+### verify(keys, sig, str)
+
+verifies a signature `sig` of the original content `str` by the author known by `keys`.
 
 ### signObj(keys, hmac_key?, obj)
 

--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ function sign(keys, msg) {
     curve
   );
 }
+exports.sign = sign;
 
 //takes a public key, signature, and a hash
 //and returns true if the signature was valid.
@@ -107,6 +108,7 @@ function verify(keys, sig, msg) {
     isBuffer(msg) ? msg : Buffer.from(msg)
   );
 }
+exports.verify = verify;
 
 // OTHER CRYTPO FUNCTIONS
 

--- a/test/index.js
+++ b/test/index.js
@@ -27,6 +27,17 @@ tape("create and load sync", function (t) {
   t.end();
 });
 
+tape("sign and verify a string", function (t) {
+  var str = "secure scuttlebutt";
+  var keys = ssbkeys.generate();
+  var sig = ssbkeys.sign(keys.private, str);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
+  t.ok(sig);
+  t.ok(ssbkeys.verify(keys, sig, str));
+  t.ok(ssbkeys.verify({ public: keys.public }, sig, str));
+  t.end();
+});
+
 tape("sign and verify a javascript object, no hmac key", function (t) {
   var obj = require("../package.json");
 


### PR DESCRIPTION
Context: we need to sign and verify strings for [rooms2 alias registration](https://ssb-ngi-pointer.github.io/rooms2/#alias-database).

Problem: `ssb-keys` implements `signObj` which works only on objects (by calling JSON.stringify), but there is actually already an implementation for `sign`, it's just not exported. Likewise for `verifyObj`.

Solution: export `sign` and `verify`.

1st commit adds a failing test, 2nd commit adds the implementation that makes tests pass.