### PR TITLE
A buffer looks like an object in js

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ exports.sign = sign;
 //takes a public key, signature, optional hmac_key and a hash
 //and returns true if the signature was valid.
 function verify(keys, sig, hmac_key, msg) {
-  if (isObject(sig))
+  if (!Buffer.isBuffer(sig) && isObject(sig))
     throw new Error(
       "signature should be base64 string, did you mean verifyObj(public, signed_obj)"
     );

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,17 @@ tape("sign and verify a string, no hmac key", function (t) {
   t.end();
 });
 
+tape("sign and verify a buffer, no hmac key", function (t) {
+  var buf = Buffer.from("secure scuttlebutt");
+  var keys = ssbkeys.generate();
+  var sig = ssbkeys.sign(keys.private, buf);
+  if (process.env.VERBOSE_TESTS) console.log(sig);
+  t.ok(sig);
+  t.ok(ssbkeys.verify(keys, sig, buf));
+  t.ok(ssbkeys.verify({ public: keys.public }, sig, buf));
+  t.end();
+});
+
 tape("sign and verify a hmaced string", function (t) {
   var str = "secure scuttlebutt";
   var keys = ssbkeys.generate();


### PR DESCRIPTION
You can't current use verify if the signature is a buffer. This fixes that problem :)